### PR TITLE
Update authorization API endpoint

### DIFF
--- a/lib/backblaze/b2.rb
+++ b/lib/backblaze/b2.rb
@@ -22,7 +22,7 @@ module Backblaze::B2
         basic_auth: {username: account_id, password: application_key}
       }
       api_path = "/#{api_path}/".gsub(/\/+/, '/')
-      response = HTTParty.get("https://api.backblaze.com#{api_path}b2_authorize_account", options)
+      response = HTTParty.get("https://api.backblazeb2.com#{api_path}b2_authorize_account", options)
       raise Backblaze::AuthError.new(response) unless response.code == 200
 
       @account_id = response['accountId']

--- a/spec/b2_spec.rb
+++ b/spec/b2_spec.rb
@@ -8,7 +8,7 @@ describe Backblaze::B2 do
       end
 
       it 'should raise AuthError on failure' do
-        stub_request(:get, 'https://failed:login@api.backblaze.com/b2api/v1/b2_authorize_account').to_return(
+        stub_request(:get, 'https://failed:login@api.backblazeb2.com/b2api/v1/b2_authorize_account').to_return(
           body: "{\"code\":\"unauthorized\",\"message\":\"invalid_authorization_headers\",\"status\":401}",
           headers: {'Content-Type' => 'application/json'},
           status: 401
@@ -28,7 +28,7 @@ describe Backblaze::B2 do
       end
 
       before do
-        stub_request(:get, 'https://real:login@api.backblaze.com/b2api/v1/b2_authorize_account').to_return(
+        stub_request(:get, 'https://real:login@api.backblazeb2.com/b2api/v1/b2_authorize_account').to_return(
           body: success.to_json,
           headers: {'Content-Type' => 'application/json'},
           status: 200,


### PR DESCRIPTION
The API host has changed: https://help.backblaze.com/hc/en-us/articles/224959187-B2-Domain-Migration-Plan
